### PR TITLE
Client could not get app's nodeId

### DIFF
--- a/client.js
+++ b/client.js
@@ -60,7 +60,7 @@ function Client (app, connection, key) {
    * @example
    * if (client.sync.state === 'synchronized')
    */
-  this.sync = new ServerSync(app.nodeId, app.log, connection, {
+  this.sync = new ServerSync(app.options.nodeId, app.log, connection, {
     credentials,
     subprotocol: app.options.subprotocol,
     timeout: app.options.timeout,

--- a/test/client.test.js
+++ b/test/client.test.js
@@ -44,6 +44,7 @@ it('uses server options', () => {
   expect(client.sync.options.subprotocol).toEqual('0.0.0')
   expect(client.sync.options.timeout).toEqual(16000)
   expect(client.sync.options.ping).toEqual(8000)
+  expect(client.sync.localNodeId).toEqual('server')
 })
 
 it('saves connection', () => {


### PR DESCRIPTION
Client could not get app's nodeId because of a typo `app.nodeId` instead of `app.options.nodeId`