### PR TITLE
Now server expects listen options (host, port, cert, key) in constructor

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,17 +47,19 @@ Create `server.js` with this boilerplate:
 ```js
 const Server = require('logux-server').Server
 
-const app = new Server({
-  subprotocol: '1.0.0',
-  supports: '1.x',
-  root: __dirname
-})
+const app = new Server(
+  Server.loadOptions(process, {
+    subprotocol: '1.0.0',
+    supports: '1.x',
+    root: __dirname
+  })
+)
 
 app.auth((userId, token) => {
   // TODO Check token and return a Promise with true or false.
 })
 
-app.listen(app.loadOptions(process))
+app.listen()
 ```
 
 

--- a/base-server.js
+++ b/base-server.js
@@ -122,11 +122,6 @@ class BaseServer {
       this.options.nodeId = `server:${ shortid.generate() }`
     }
 
-    /**
-     * Options used to start server.
-     * @type {object}
-     */
-
     if (this.options.key && !this.options.cert) {
       throw new Error('You must set cert option too if you use key option')
     }

--- a/reporters/common.js
+++ b/reporters/common.js
@@ -26,12 +26,12 @@ module.exports = {
 
   getAppUrl (app) {
     let url
-    if (app.listenOptions.server) {
+    if (app.options.server) {
       url = 'Custom HTTP server'
     } else {
-      const protocol = app.listenOptions.cert ? 'wss://' : 'ws://'
-      const host = app.listenOptions.host
-      const port = app.listenOptions.port
+      const protocol = app.options.cert ? 'wss://' : 'ws://'
+      const host = app.options.host
+      const port = app.options.port
       url = `${ protocol }${ host }:${ port }`
     }
     return url

--- a/server.js
+++ b/server.js
@@ -154,24 +154,23 @@ class Server extends BaseServer {
    * Load options from command-line arguments and/or environment
    *
    * @param {object} process Current process object.
-   * @param {object} defaults Default options.
+   * @param {object} options Server options.
    * @return {object} Parsed options object.
    *
    * @example
    * app.listen(app.loadOptions(process, { port: 31337 }))
    */
-  loadOptions (process, defaults) {
-    defaults = defaults || { }
+  static loadOptions (process, options) {
+    options = options || { }
 
     const argv = yargs.parse(process.argv)
     const env = process.env
 
-    return {
-      host: argv.h || env.LOGUX_HOST || defaults.host,
-      port: parseInt(argv.p || env.LOGUX_PORT || defaults.port, 10),
-      cert: argv.c || env.LOGUX_CERT || defaults.cert,
-      key: argv.k || env.LOGUX_KEY || defaults.key
-    }
+    options.host = options.host || argv.h || env.LOGUX_HOST
+    options.port = parseInt(options.port || argv.p || env.LOGUX_PORT, 10)
+    options.cert = options.cert || argv.c || env.LOGUX_CERT
+    options.key = options.key || argv.k || env.LOGUX_KEY
+    return options
   }
 }
 

--- a/server.js
+++ b/server.js
@@ -98,16 +98,23 @@ yargs
  *
  * @example
  * import { Server } from 'logux-server'
- * const app = new Server({
+ *
+ * let env = process.env.NODE_ENV || 'development'
+ * let envOptions = {}
+ * if (env === 'production') {
+ *   envOptions = {
+ *     cert: 'cert.pem',
+ *     key: 'key.pem'
+ *   }
+ * }
+ *
+ * const app = new Server(Object.assign({
  *   subprotocol: '1.0.0',
  *   supports: '1.x || 0.x',
  *   root: __dirname
- * })
- * if (app.env === 'production') {
- *   app.listen({ cert: 'cert.pem', key: 'key.pem' })
- * } else {
- *   app.listen()
- * }
+ * }, envOptions))
+ *
+ * app.listen()
  *
  * @extends BaseServer
  */
@@ -158,7 +165,12 @@ class Server extends BaseServer {
    * @return {object} Parsed options object.
    *
    * @example
-   * app.listen(app.loadOptions(process, { port: 31337 }))
+   * const app = new Server(Server.loadOptions(process, {
+   *   subprotocol: '1.0.0',
+   *   supports: '1.x',
+   *   root: __dirname,
+   *   port: 31337
+   * }))
    */
   static loadOptions (process, options) {
     options = options || { }

--- a/test/bunyan-reporter.test.js
+++ b/test/bunyan-reporter.test.js
@@ -28,10 +28,11 @@ const app = new BaseServer({
   nodeId: 'server:H1f8LAyzl',
   subprotocol: '2.5.0',
   supports: '2.x || 1.x',
+  host: '127.0.0.1',
+  port: 1337,
   reporter: 'bunyan',
   bunyanLogger: log
 })
-app.listenOptions = { host: '127.0.0.1', port: 1337 }
 
 const ws = {
   upgradeReq: {
@@ -85,10 +86,13 @@ it('reports production', () => {
     nodeId: 'server:H1f8LAyzl',
     subprotocol: '1.0.0',
     supports: '1.x',
+    cert: 'A',
+    key: 'B',
+    host: '0.0.0.0',
+    port: 1337,
     reporter: 'bunyan',
     bunyanLogger: log
   })
-  wss.listenOptions = { cert: 'A', host: '0.0.0.0', port: 1337 }
 
   expect(reportersOut('listen', wss)).toMatchSnapshot()
 })
@@ -100,10 +104,10 @@ it('reports http', () => {
     nodeId: 'server:H1f8LAyzl',
     subprotocol: '1.0.0',
     supports: '1.x',
+    server: createServer(),
     reporter: 'bunyan',
     bunyanLogger: log
   })
-  http.listenOptions = { server: createServer() }
 
   expect(reportersOut('listen', http)).toMatchSnapshot()
 })
@@ -198,9 +202,10 @@ it('handles error in production', () => {
     pid: 21384,
     nodeId: 'server:H1f8LAyzl',
     subprotocol: '2.5.0',
-    supports: '2.x || 1.x'
+    supports: '2.x || 1.x',
+    host: '127.0.0.1',
+    port: 1000
   })
-  http.listenOptions = { host: '127.0.0.1', port: 1000 }
 
   expect(reportersOut('error', app, { code: 'EACCES', port: 1000 }, http))
     .toMatchSnapshot()

--- a/test/human-reporter.test.js
+++ b/test/human-reporter.test.js
@@ -23,9 +23,10 @@ const app = new BaseServer({
   pid: 21384,
   nodeId: 'server:H1f8LAyzl',
   subprotocol: '2.5.0',
-  supports: '2.x || 1.x'
+  supports: '2.x || 1.x',
+  host: '127.0.0.1',
+  port: 1337
 })
-app.listenOptions = { host: '127.0.0.1', port: 1337 }
 
 const ws = {
   upgradeReq: {
@@ -86,9 +87,12 @@ it('reports production', () => {
     pid: 21384,
     nodeId: 'server:H1f8LAyzl',
     subprotocol: '1.0.0',
-    supports: '1.x'
+    supports: '1.x',
+    cert: 'A',
+    key: 'B',
+    host: '0.0.0.0',
+    port: 1337
   })
-  wss.listenOptions = { cert: 'A', host: '0.0.0.0', port: 1337 }
 
   expect(reportersOut('listen', wss)).toMatchSnapshot()
 })
@@ -99,9 +103,9 @@ it('reports http', () => {
     pid: 21384,
     nodeId: 'server:H1f8LAyzl',
     subprotocol: '1.0.0',
-    supports: '1.x'
+    supports: '1.x',
+    server: createServer()
   })
-  http.listenOptions = { server: createServer() }
 
   expect(reportersOut('listen', http)).toMatchSnapshot()
 })
@@ -196,9 +200,10 @@ it('handles error in production', () => {
     pid: 21384,
     nodeId: 'server:H1f8LAyzl',
     subprotocol: '2.5.0',
-    supports: '2.x || 1.x'
+    supports: '2.x || 1.x',
+    host: '127.0.0.1',
+    port: 1000
   })
-  http.listenOptions = { host: '127.0.0.1', port: 1000 }
 
   expect(reportersOut('error', app, { code: 'EACCES', port: 1000 }, http))
     .toMatchSnapshot()

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -94,7 +94,7 @@ afterEach(() => {
 })
 
 it('uses cli args for options', () => {
-  const options = Server.prototype.loadOptions({
+  const options = Server.loadOptions({
     argv: ['', '--port', '31337', '--host', '192.168.1.1'],
     env: { }
   })
@@ -106,7 +106,7 @@ it('uses cli args for options', () => {
 })
 
 it('uses env for options', () => {
-  const options = Server.prototype.loadOptions({
+  const options = Server.loadOptions({
     argv: [],
     env: { LOGUX_HOST: '127.0.1.1', LOGUX_PORT: 31337 }
   })
@@ -116,7 +116,7 @@ it('uses env for options', () => {
 })
 
 it('uses combined options', () => {
-  const options = Server.prototype.loadOptions({
+  const options = Server.loadOptions({
     env: { LOGUX_CERT: './cert.pem' },
     argv: ['', '--key', './key.pem']
   }, { port: 31337 })
@@ -126,18 +126,23 @@ it('uses combined options', () => {
   expect(options.key).toEqual('./key.pem')
 })
 
-it('uses arg, env, defaults options in given priority', () => {
-  const options1 = Server.prototype.loadOptions({
+it('uses arg, env, options in given priority', () => {
+  const options1 = Server.loadOptions({
     argv: ['', '--port', '31337'],
     env: { LOGUX_PORT: 21337 }
   }, { port: 11337 })
-  const options2 = Server.prototype.loadOptions({
+  const options2 = Server.loadOptions({
+    argv: ['', '--port', '31337'],
+    env: { LOGUX_PORT: 21337 }
+  })
+  const options3 = Server.loadOptions({
     argv: [],
     env: { LOGUX_PORT: 21337 }
-  }, { port: 11337 })
+  })
 
-  expect(options1.port).toEqual(31337)
-  expect(options2.port).toEqual(21337)
+  expect(options1.port).toEqual(11337)
+  expect(options2.port).toEqual(31337)
+  expect(options3.port).toEqual(21337)
 })
 
 it('destroys everything on exit', () => checkOut('destroy.js'))

--- a/test/servers/bunyan-custom.js
+++ b/test/servers/bunyan-custom.js
@@ -14,10 +14,11 @@ const app = new Server({
   nodeId: 'server',
   subprotocol: '1.0.0',
   supports: '1.x',
+  port: 2000,
   reporter: 'bunyan',
   bunyanLogger: logger
 })
 
 app.auth(() => Promise.resolve(true))
 
-app.listen({ port: 2000 })
+app.listen()

--- a/test/servers/bunyan.js
+++ b/test/servers/bunyan.js
@@ -8,9 +8,10 @@ const app = new Server({
   nodeId: 'server',
   subprotocol: '1.0.0',
   supports: '1.x',
+  port: 2000,
   reporter: 'bunyan'
 })
 
 app.auth(() => Promise.resolve(true))
 
-app.listen({ port: 2000 })
+app.listen()

--- a/test/servers/destroy.js
+++ b/test/servers/destroy.js
@@ -7,7 +7,8 @@ const Server = require('../../server')
 const app = new Server({
   nodeId: 'server',
   subprotocol: '1.0.0',
-  supports: '1.x'
+  supports: '1.x',
+  port: 2000
 })
 
 app.auth(() => Promise.resolve(true))
@@ -19,7 +20,7 @@ app.unbind.push(() => new Promise(resolve => {
   }, 10)
 }))
 
-app.listen({ port: 2000 })
+app.listen()
 
 process.on('message', msg => {
   if (msg === 'close') {

--- a/test/servers/eacces.js
+++ b/test/servers/eacces.js
@@ -7,9 +7,10 @@ const Server = require('../../server')
 const app = new Server({
   nodeId: 'server',
   subprotocol: '1.0.0',
-  supports: '1.x'
+  supports: '1.x',
+  port: 1000
 })
 
 app.auth(() => Promise.resolve(true))
 
-app.listen({ port: 1000 })
+app.listen()

--- a/test/servers/eaddrinuse.js
+++ b/test/servers/eaddrinuse.js
@@ -7,9 +7,10 @@ const Server = require('../../server')
 const app = new Server({
   nodeId: 'server',
   subprotocol: '1.0.0',
-  supports: '1.x'
+  supports: '1.x',
+  port: 2001
 })
 
 app.auth(() => Promise.resolve(true))
 
-app.listen({ port: 2001 })
+app.listen()

--- a/test/servers/options.js
+++ b/test/servers/options.js
@@ -4,15 +4,15 @@
 
 const Server = require('../../server')
 
-const app = new Server({
-  nodeId: 'server',
-  subprotocol: '1.0.0',
-  supports: '1.x'
-})
+const app = new Server(
+  Server.loadOptions(process, {
+    nodeId: 'server',
+    subprotocol: '1.0.0',
+    supports: '1.x',
+    host: '127.0.0.1'
+  })
+)
 
 app.auth(() => Promise.resolve(true))
 
-app.listen(app.loadOptions(process, {
-  port: '1338',
-  host: '127.0.0.1'
-}))
+app.listen()


### PR DESCRIPTION
During configs merge (as we discussed at #24) I've changed options priority of method `loadOptions`: `options.host = options.host || argv.h || env.LOGUX_HOST`. Previously it was really default options for parser function. Now it become a wrapper for all options and you want them to be provided as is. It will be magic if some of them will change during operations.

You will be very surprised if this server will start at port 2000 because of env params:

```js
const app = new Server(Server.loadOptions(process, {
  subprotocol: '1.0.0',
  supports: '1.x',
  root: __dirname,
  port: 11337
}))
```
I think it will be messy behavior. If you want to use env params then you shouldn't provide option at all.